### PR TITLE
Add theme constants and unify colors

### DIFF
--- a/Frontend/app/Clientes.tsx
+++ b/Frontend/app/Clientes.tsx
@@ -1,6 +1,7 @@
 import { View, Text, StyleSheet, ScrollView } from "react-native";
 import Header from "@/components/Header";
 import ButtonHeader from "@/components/ButtonHeader";
+import { colors } from "@/theme";
 
 export default function Clientes() {
   // dados mockados
@@ -53,11 +54,11 @@ export default function Clientes() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "white",
+    backgroundColor: colors.surface,
   },
   tableHeader: {
     flexDirection: "row",
-    backgroundColor: "#f5f5f5",
+    backgroundColor: colors.background,
     paddingVertical: 12,
     paddingHorizontal: 8,
     borderBottomWidth: 1,

--- a/Frontend/app/Estoque.tsx
+++ b/Frontend/app/Estoque.tsx
@@ -1,5 +1,6 @@
 import Header from "@/components/Header";
 import { View, Text, StyleSheet, TouchableOpacity, Picker } from "react-native";
+import { colors } from "@/theme";
 
 export default function Estoque() {
   return (
@@ -50,7 +51,7 @@ export default function Estoque() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "white",
+    backgroundColor: colors.surface,
   },
   mainContent: {
     flex: 1,
@@ -70,14 +71,14 @@ const styles = StyleSheet.create({
     marginBottom: 15,
   },
   orangeButton: {
-    backgroundColor: "#F27A2F",
+    backgroundColor: colors.accent,
     padding: 12,
     borderRadius: 8,
     marginBottom: 10,
     alignItems: "center",
   },
   buttonText: {
-    color: "white",
+    color: colors.surface,
     fontWeight: "bold",
   },
   dropdown: {

--- a/Frontend/app/NovoPedido.tsx
+++ b/Frontend/app/NovoPedido.tsx
@@ -1,5 +1,6 @@
 import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import Header from "@/components/Header";
+import { colors } from "@/theme";
 
 export default function NovoPedido() {
 
@@ -86,8 +87,8 @@ export default function NovoPedido() {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,           
-    backgroundColor: "white",
+    flex: 1,
+    backgroundColor: colors.surface,
   },
   mainContent: {
     flex: 1,            
@@ -118,18 +119,18 @@ const styles = StyleSheet.create({
     marginBottom: 15,   
   },
   orangeButton: {
-    backgroundColor: '#F27A2F', 
+    backgroundColor: colors.accent,
     padding: 12,
     borderRadius: 8,    
     marginBottom: 10,   
     alignItems: 'center', 
   },
   buttonText: {
-    color: 'white',
+    color: colors.surface,
     fontWeight: 'bold',
   },
   infoBox: {
-    backgroundColor: '#f9f9f9', 
+    backgroundColor: colors.background,
     padding: 15,
     borderRadius: 8,
   },
@@ -146,7 +147,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1, 
   },
   summaryBox: {
-    backgroundColor: '#f5f5f5',
+    backgroundColor: colors.background,
     padding: 20,
     borderRadius: 8,
     marginTop: 20,
@@ -158,7 +159,7 @@ const styles = StyleSheet.create({
   totalPrice: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: '#F27A2F',  
+    color: colors.accent,
     textAlign: 'center',
     marginBottom: 20,
   },

--- a/Frontend/app/_layout.tsx
+++ b/Frontend/app/_layout.tsx
@@ -1,4 +1,5 @@
 import { Drawer } from "expo-router/drawer";
+import { colors } from "@/theme";
 
 export default function Layout() {
   return (
@@ -6,13 +7,13 @@ export default function Layout() {
       screenOptions={{
         headerShown: false,
         drawerStyle: {
-          backgroundColor: "#f19f5e",
+          backgroundColor: colors.drawer,
           width: 280,
           paddingTop: 40,
         },
-        drawerActiveBackgroundColor: "#f97f20",
-        drawerActiveTintColor: "#fff",
-        drawerInactiveTintColor: "#fff",
+        drawerActiveBackgroundColor: colors.secondary,
+        drawerActiveTintColor: colors.surface,
+        drawerInactiveTintColor: colors.surface,
       }}
     >
       <Drawer.Screen name="index" options={{ title: "Início" }} />

--- a/Frontend/app/index.tsx
+++ b/Frontend/app/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { View, Text, StyleSheet } from "react-native";
 import { Link } from "expo-router";
 import Header from "@/components/Header";
+import { colors } from "@/theme";
 
 export default function Home() {
   return (
@@ -34,10 +35,10 @@ export default function Home() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "white",
+    backgroundColor: colors.surface,
   },
   header: {
-    backgroundColor: "#f97f20",
+    backgroundColor: colors.secondary,
     paddingVertical: 15,
     alignItems: "center",
     justifyContent: "center",
@@ -45,7 +46,7 @@ const styles = StyleSheet.create({
   headerText: {
     fontSize: 24,
     fontWeight: "bold",
-    color: "#000",
+    color: colors.text,
   },
   content: {
     flex: 0.9,
@@ -57,7 +58,7 @@ const styles = StyleSheet.create({
     marginBottom: 40,
   },
   menuItem: {
-    backgroundColor: "#F27A2F",
+    backgroundColor: colors.accent,
     paddingVertical: 25,
     paddingHorizontal: 30,
     marginBottom: 15,
@@ -70,6 +71,6 @@ const styles = StyleSheet.create({
   menuText: {
     fontSize: 16,
     fontWeight: "bold",
-    color: "white",
+    color: colors.surface,
   },
 });

--- a/Frontend/components/ButtonHeader.tsx
+++ b/Frontend/components/ButtonHeader.tsx
@@ -1,4 +1,5 @@
 import { View, TouchableOpacity, Text, StyleSheet } from "react-native";
+import { colors } from "@/theme";
 
 interface ButtonHeaderProps {
   buttons: (
@@ -43,7 +44,7 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: "row",
     flexWrap: "wrap",
-    backgroundColor: "#f0f0f0",
+    backgroundColor: colors.background,
     padding: 8,
     justifyContent: "space-around",
   },
@@ -52,7 +53,7 @@ const styles = StyleSheet.create({
     height: 40,
     margin: 4,
     borderRadius: 6,
-    backgroundColor: "#e0e0e0",
+    backgroundColor: colors.gray,
     justifyContent: "center",
   },
   buttonInner: {
@@ -65,7 +66,7 @@ const styles = StyleSheet.create({
     marginRight: 6,
   },
   buttonText: {
-    color: "#333",
+    color: colors.text,
     fontWeight: "500",
   },
 });

--- a/Frontend/components/CriarProduto.tsx
+++ b/Frontend/components/CriarProduto.tsx
@@ -4,6 +4,7 @@ import { criarProduto } from "@/api";
 import FloatingLabelInput from "@/components/FloatingLabelInput";
 import { fetchCategorias } from "@/api";
 import SelectCategoria from "./SelectCategoria";
+import { colors } from "@/theme";
 
 export default function CriarProduto({
   visible,
@@ -141,7 +142,7 @@ const styles = StyleSheet.create({
   },
   modalContent: {
     justifyContent: "center",
-    backgroundColor: "white",
+    backgroundColor: colors.surface,
     margin: 20,
     padding: 20,
     borderRadius: 10,
@@ -149,7 +150,7 @@ const styles = StyleSheet.create({
     minHeight: "55%",
   },
   button: {
-    backgroundColor: "#f97f20",
+    backgroundColor: colors.secondary,
     padding: 10,
     marginBottom: 10,
   },
@@ -158,7 +159,7 @@ const styles = StyleSheet.create({
     padding: 10,
   },
   buttonText: {
-    color: "white",
+    color: colors.surface,
     textAlign: "center",
   },
 });

--- a/Frontend/components/EditarProduto.tsx
+++ b/Frontend/components/EditarProduto.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { editarProduto } from "@/api";
 import FloatingLabelInput from "./FloatingLabelInput";
 import SelectCategoria from "./SelectCategoria";
+import { colors } from "@/theme";
 
 export default function EditarProduto({
   visible,
@@ -129,7 +130,7 @@ const styles = StyleSheet.create({
   },
   modalContent: {
     justifyContent: "center",
-    backgroundColor: "white",
+    backgroundColor: colors.surface,
     margin: 20,
     padding: 20,
     borderRadius: 10,
@@ -137,7 +138,7 @@ const styles = StyleSheet.create({
     minHeight: "55%",
   },
   button: {
-    backgroundColor: "#f97f20",
+    backgroundColor: colors.secondary,
     padding: 10,
     marginBottom: 10,
   },
@@ -146,7 +147,7 @@ const styles = StyleSheet.create({
     padding: 10,
   },
   buttonText: {
-    color: "white",
+    color: colors.surface,
     textAlign: "center",
   },
 });

--- a/Frontend/components/Header.tsx
+++ b/Frontend/components/Header.tsx
@@ -2,6 +2,7 @@ import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
 import { FontAwesome6 } from "@expo/vector-icons";
 import { useNavigation } from "expo-router";
 import { DrawerActions } from "@react-navigation/native";
+import { colors } from "@/theme";
 
 export default function Header({ title }: { title: string }) {
   const navigation = useNavigation();
@@ -12,7 +13,7 @@ export default function Header({ title }: { title: string }) {
         style={styles.menuButton}
         onPress={() => navigation.dispatch(DrawerActions.toggleDrawer())}
       >
-        <FontAwesome6 name="bars" size={20} color="#000" />
+        <FontAwesome6 name="bars" size={20} color={colors.text} />
       </TouchableOpacity>
 
       <View style={styles.titleContainer}>
@@ -24,7 +25,7 @@ export default function Header({ title }: { title: string }) {
 
 const styles = StyleSheet.create({
   header: {
-    backgroundColor: "#F97A56",
+    backgroundColor: colors.primary,
     paddingVertical: 15,
     paddingHorizontal: 16,
     flexDirection: "row",
@@ -43,6 +44,6 @@ const styles = StyleSheet.create({
   titleText: {
     fontSize: 20,
     fontWeight: "bold",
-    color: "#000",
+    color: colors.text,
   },
 });

--- a/Frontend/theme.ts
+++ b/Frontend/theme.ts
@@ -1,0 +1,25 @@
+export const colors = {
+  primary: '#F97A56',
+  accent: '#F27A2F',
+  secondary: '#f97f20',
+  background: '#f5f5f5',
+  surface: '#ffffff',
+  text: '#000000',
+  gray: '#e0e0e0',
+  drawer: '#f19f5e',
+};
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+};
+
+export const fontSizes = {
+  sm: 14,
+  md: 16,
+  lg: 20,
+};
+
+export default { colors, spacing, fontSizes };


### PR DESCRIPTION
## Summary
- centralize color and spacing settings in a new `theme.ts`
- use the new theme colors in header and various components
- update screens to use the shared theme colors

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686d330c56ac8330866f0b0635c389ae