### PR TITLE
Implement frontend cliente management

### DIFF
--- a/Frontend/api.ts
+++ b/Frontend/api.ts
@@ -48,3 +48,40 @@ export const fetchProdutosPorCategoria = async (id: number) => {
   if (!res.ok) throw new Error("Erro ao buscar produtos da categoria");
   return res.json();
 };
+
+// Clientes
+export const fetchClientes = async () => {
+  const res = await fetch(`${BASE_URL}/clientes`);
+  if (!res.ok) throw new Error("Erro ao buscar clientes");
+  return res.json();
+};
+
+export const criarCliente = async (cliente: any) => {
+  const res = await fetch(`${BASE_URL}/clientes`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(cliente),
+  });
+  if (!res.ok) {
+    const errorData = await res.json();
+    throw new Error(errorData.error || "Erro ao criar cliente");
+  }
+  return res.json();
+};
+
+export const editarCliente = async (id: number, dados: any) => {
+  const res = await fetch(`${BASE_URL}/clientes/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(dados),
+  });
+  if (!res.ok) throw new Error("Erro ao atualizar cliente");
+  return res.json();
+};
+
+export const deletarCliente = async (id: number) => {
+  const res = await fetch(`${BASE_URL}/clientes/${id}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) throw new Error("Erro ao deletar cliente");
+};

--- a/Frontend/app/Clientes.tsx
+++ b/Frontend/app/Clientes.tsx
@@ -1,61 +1,113 @@
-import { View, Text, StyleSheet, ScrollView } from "react-native";
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator } from "react-native";
 import Header from "@/components/Header";
 import ButtonHeader from "@/components/ButtonHeader";
+import CriarCliente from "../components/CriarCliente";
+import EditarCliente from "../components/EditarCliente";
+import { useClientes } from "../lib/hooks/useClientes";
+import { deletarCliente } from "@/api";
 import { colors } from "@/theme";
+import { useState } from "react";
+import FontAwesome6 from "@expo/vector-icons/FontAwesome6";
 
 export default function Clientes() {
-  // dados mockados
-  const clientes = [
-    { id: 1, nome: "Maria Silva", crianca: "Sim", endereco: "Rua A, 123", taxa: "5%" },
-    { id: 2, nome: "João Santos", crianca: "Não", endereco: "Av. B, 456", taxa: "10%" },
-  ];
+  const { clientes, carregando, carregar } = useClientes();
+  const [clienteSelecionado, setClienteSelecionado] = useState<any>(null);
+  const [modalNovoVisivel, setModalNovoVisivel] = useState(false);
+  const [modalEditarVisivel, setModalEditarVisivel] = useState(false);
 
-  // Funções para os botões (por enquanto vazias)
-  const handleBuscar = () => console.log("Buscar clientes");
-  const handleEditar = () => console.log("Editar cliente");
-  const handleNovo = () => console.log("Novo cliente");
+  const handleDeletar = async () => {
+    if (!clienteSelecionado) {
+      alert("Selecione um cliente para deletar");
+      return;
+    }
+    const confirmar = confirm("Tem certeza que deseja deletar este cliente?");
+    if (!confirmar) return;
+    try {
+      await deletarCliente(clienteSelecionado.id);
+      alert("Cliente deletado com sucesso!");
+      setClienteSelecionado(null);
+      carregar();
+    } catch (error) {
+      alert("Erro ao deletar cliente");
+    }
+  };
 
   return (
     <View style={styles.container}>
       <Header title="Clientes" />
-      
-      {/* Novo componente ButtonHeader */}
       <ButtonHeader
         buttons={[
-          { label: "Buscar", onPress: handleBuscar },
-          { label: "Editar", onPress: handleEditar },
-          { label: "Novo", onPress: handleNovo },
+          {
+            label: "Novo Cliente",
+            onPress: () => setModalNovoVisivel(true),
+            icon: <FontAwesome6 name="plus" size={16} color="black" />,
+          },
+          {
+            label: "Editar",
+            onPress: () => {
+              if (!clienteSelecionado) return alert("Selecione um cliente primeiro");
+              setModalEditarVisivel(true);
+            },
+            icon: <FontAwesome6 name="pen" size={16} color="black" />,
+          },
+          {
+            label: "Deletar",
+            onPress: handleDeletar,
+            icon: <FontAwesome6 name="trash" size={16} color="black" />,
+          },
         ]}
       />
 
-      {/* Cabeçalho da tabela */}
       <View style={styles.tableHeader}>
         <Text style={[styles.headerText, { flex: 2 }]}>Nome</Text>
-        <Text style={styles.headerText}>Criança</Text>
-        <Text style={[styles.headerText, { flex: 2 }]}>Endereço</Text>
-        <Text style={styles.headerText}>Taxa</Text>
+        <Text style={[styles.headerText, { flex: 3 }]}>Endereço</Text>
       </View>
 
-      {/* Lista de clientes */}
-      <ScrollView style={styles.listContainer}>
-        {clientes.map(cliente => (
-          <View key={cliente.id} style={styles.tableRow}>
-            <Text style={[styles.cellText, { flex: 2 }]}>{cliente.nome}</Text>
-            <Text style={styles.cellText}>{cliente.crianca}</Text>
-            <Text style={[styles.cellText, { flex: 2 }]}>{cliente.endereco}</Text>
-            <Text style={styles.cellText}>{cliente.taxa}</Text>
-          </View>
-        ))}
-      </ScrollView>
+      {carregando ? (
+        <ActivityIndicator style={{ marginTop: 20 }} />
+      ) : (
+        <ScrollView style={styles.listContainer}>
+          {clientes.map((cliente: any, index: number) => (
+            <TouchableOpacity
+              key={cliente.id}
+              onPress={() => {
+                if (clienteSelecionado?.id === cliente.id) {
+                  setClienteSelecionado(null);
+                } else {
+                  setClienteSelecionado(cliente);
+                }
+              }}
+              style={[
+                styles.tableRow,
+                index % 2 === 0 && { backgroundColor: "#fafafa" },
+                clienteSelecionado?.id === cliente.id && { backgroundColor: "#e0f7fa" },
+              ]}
+            >
+              <Text style={[styles.cellText, { flex: 2 }]}>{cliente.nome}</Text>
+              <Text style={[styles.cellText, { flex: 3 }]}>{cliente.endereco}</Text>
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+      )}
+
+      <CriarCliente
+        visible={modalNovoVisivel}
+        onClose={() => setModalNovoVisivel(false)}
+        onClienteCriado={carregar}
+      />
+
+      <EditarCliente
+        visible={modalEditarVisivel}
+        onClose={() => setModalEditarVisivel(false)}
+        cliente={clienteSelecionado}
+        onAtualizado={carregar}
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.surface,
-  },
+  container: { flex: 1, backgroundColor: colors.surface },
   tableHeader: {
     flexDirection: "row",
     backgroundColor: colors.background,
@@ -64,23 +116,13 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: "#ddd",
   },
-  headerText: {
-    fontWeight: "bold",
-    flex: 1,
-    textAlign: "center",
-  },
-  listContainer: {
-    flex: 1,
-    paddingHorizontal: 8,
-  },
+  headerText: { fontWeight: "bold", flex: 1, textAlign: "center" },
+  listContainer: { flex: 1, paddingHorizontal: 8 },
   tableRow: {
     flexDirection: "row",
     paddingVertical: 12,
     borderBottomWidth: 1,
     borderBottomColor: "#eee",
   },
-  cellText: {
-    flex: 1,
-    textAlign: "center",
-  },
+  cellText: { flex: 1, textAlign: "center" },
 });

--- a/Frontend/components/CriarCliente.tsx
+++ b/Frontend/components/CriarCliente.tsx
@@ -1,0 +1,95 @@
+import { View, Modal, Text, Pressable, StyleSheet } from "react-native";
+import { useState } from "react";
+import FloatingLabelInput from "@/components/FloatingLabelInput";
+import { criarCliente } from "@/api";
+import { colors } from "@/theme";
+
+export default function CriarCliente({ visible, onClose, onClienteCriado }: any) {
+  const [nome, setNome] = useState("");
+  const [endereco, setEndereco] = useState("");
+  const [erros, setErros] = useState<{ [key: string]: boolean }>({});
+  const [tentouSalvar, setTentouSalvar] = useState(false);
+
+  const handleSalvar = async () => {
+    setTentouSalvar(true);
+    const novoErros: any = {};
+    if (!nome) novoErros.nome = true;
+    if (!endereco) novoErros.endereco = true;
+    if (Object.keys(novoErros).length > 0) {
+      setErros(novoErros);
+      alert("Preencha todos os campos obrigatórios.");
+      return;
+    }
+    try {
+      await criarCliente({ nome, endereco });
+      setNome("");
+      setEndereco("");
+      onClienteCriado();
+      onClose();
+      alert("Cliente criado com sucesso!");
+    } catch (error: any) {
+      if (error.message === "Cliente idêntico já existe") {
+        alert("Já existe um cliente com os mesmos dados.");
+        setErros({ nome: true, endereco: true });
+      } else {
+        alert("Erro ao salvar");
+      }
+    }
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent>
+      <View style={styles.modalBackground}>
+        <View style={styles.modalContent}>
+          <Text style={{ fontWeight: "bold", marginBottom: 10 }}>Novo Cliente</Text>
+          <FloatingLabelInput
+            label="Nome"
+            value={nome}
+            onChangeText={setNome}
+            erro={tentouSalvar && erros.nome}
+          />
+          <FloatingLabelInput
+            label="Endereço"
+            value={endereco}
+            onChangeText={setEndereco}
+            erro={tentouSalvar && erros.endereco}
+          />
+
+          <Pressable onPress={handleSalvar} style={styles.button}>
+            <Text style={{ color: "white", textAlign: "center" }}>Salvar</Text>
+          </Pressable>
+          <Pressable onPress={onClose} style={styles.cancelButton}>
+            <Text style={{ color: "white", textAlign: "center" }}>Cancelar</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modalBackground: {
+    flex: 1,
+    backgroundColor: "#000000aa",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  modalContent: {
+    justifyContent: "center",
+    backgroundColor: colors.surface,
+    margin: 20,
+    padding: 20,
+    borderRadius: 10,
+    width: "40%",
+  },
+  button: {
+    backgroundColor: colors.secondary,
+    padding: 10,
+    marginBottom: 10,
+  },
+  cancelButton: {
+    backgroundColor: "gray",
+    padding: 10,
+  },
+});
+

--- a/Frontend/components/EditarCliente.tsx
+++ b/Frontend/components/EditarCliente.tsx
@@ -1,0 +1,97 @@
+import { View, Modal, Text, Pressable, StyleSheet } from "react-native";
+import { useState, useEffect } from "react";
+import FloatingLabelInput from "@/components/FloatingLabelInput";
+import { editarCliente } from "@/api";
+import { colors } from "@/theme";
+
+export default function EditarCliente({ visible, onClose, cliente, onAtualizado }: any) {
+  const [nome, setNome] = useState("");
+  const [endereco, setEndereco] = useState("");
+  const [erros, setErros] = useState<{ [key: string]: boolean }>({});
+  const [tentouSalvar, setTentouSalvar] = useState(false);
+
+  useEffect(() => {
+    if (cliente) {
+      setNome(cliente.nome || "");
+      setEndereco(cliente.endereco || "");
+      setErros({});
+      setTentouSalvar(false);
+    }
+  }, [cliente]);
+
+  const handleSalvar = async () => {
+    setTentouSalvar(true);
+    const novoErros: any = {};
+    if (!nome) novoErros.nome = true;
+    if (!endereco) novoErros.endereco = true;
+    if (Object.keys(novoErros).length > 0) {
+      setErros(novoErros);
+      alert("Preencha todos os campos obrigatórios.");
+      return;
+    }
+    try {
+      await editarCliente(cliente.id, { nome, endereco });
+      onAtualizado();
+      onClose();
+      alert("Cliente atualizado com sucesso!");
+    } catch (error) {
+      alert("Erro ao atualizar");
+    }
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent>
+      <View style={styles.modalBackground}>
+        <View style={styles.modalContent}>
+          <Text style={{ fontWeight: "bold", marginBottom: 10 }}>Editar Cliente</Text>
+          <FloatingLabelInput
+            label="Nome"
+            value={nome}
+            onChangeText={setNome}
+            erro={tentouSalvar && erros.nome}
+          />
+          <FloatingLabelInput
+            label="Endereço"
+            value={endereco}
+            onChangeText={setEndereco}
+            erro={tentouSalvar && erros.endereco}
+          />
+
+          <Pressable onPress={handleSalvar} style={styles.button}>
+            <Text style={{ color: "white", textAlign: "center" }}>Atualizar</Text>
+          </Pressable>
+          <Pressable onPress={onClose} style={styles.cancelButton}>
+            <Text style={{ color: "white", textAlign: "center" }}>Cancelar</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modalBackground: {
+    flex: 1,
+    backgroundColor: "#000000aa",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  modalContent: {
+    justifyContent: "center",
+    backgroundColor: colors.surface,
+    margin: 20,
+    padding: 20,
+    borderRadius: 10,
+    width: "40%",
+  },
+  button: {
+    backgroundColor: colors.secondary,
+    padding: 10,
+    marginBottom: 10,
+  },
+  cancelButton: {
+    backgroundColor: "gray",
+    padding: 10,
+  },
+});
+

--- a/Frontend/lib/hooks/useClientes.ts
+++ b/Frontend/lib/hooks/useClientes.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+import { fetchClientes } from "@/api";
+
+export function useClientes() {
+  const [clientes, setClientes] = useState([]);
+  const [carregando, setCarregando] = useState(true);
+
+  const carregar = async () => {
+    setCarregando(true);
+    try {
+      const data = await fetchClientes();
+      setClientes(data);
+    } finally {
+      setCarregando(false);
+    }
+  };
+
+  useEffect(() => {
+    carregar();
+  }, []);
+
+  return { clientes, setClientes, carregando, carregar };
+}
+
+export default useClientes;


### PR DESCRIPTION
## Summary
- support cliente API in frontend
- add cliente management hook
- add modal forms to create and edit clientes
- integrate new UI on Clientes page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686d3f19b6e0833090b676dddbda8562